### PR TITLE
Add html and markdown formatting for messages.

### DIFF
--- a/lib/types/Message.js
+++ b/lib/types/Message.js
@@ -36,6 +36,32 @@ export default class Message extends Base {
   }
 
   /**
+   * Set text of the message in HTML format
+   * @param  {string} text Message's content in HTML format
+   * @return {object} returns the message object
+   */
+  html(text) {
+    this.properties.parse_mode = 'HTML';
+    if (text) {
+      this.properties.text = text;
+    }
+    return this;
+  }
+
+  /**
+   * Set text of the message in Markdown format
+   * @param  {string} text Message's content in Markdown format
+   * @return {object} returns the message object
+   */
+  markdown(text) {
+    this.properties.parse_mode = 'Markdown';
+    if (text) {
+      this.properties.text = text;
+    }
+    return this;
+  }
+
+  /**
    * Set reply_to_message_id of the message
    * @param  {number} id message_id of the message to reply to
    * @return {object} returns the message object


### PR DESCRIPTION
This patch adds html and markdown formatting for messages.

``` javascript
var htmlText = '<i>italic</i> and <b>bold</b>';
var markdownText = '_italic_ and *bold*';

// new way
bot.send(new Message().html(htmlText).to(chat_id));
bot.send(new Message().markdown(markdownText).to(chat_id));

bot.send(new Message().text(htmlText).html().to(chat_id));
bot.send(new Message().text(markdownText).markdown().to(chat_id));

// old way
bot.send(new Message({parse_mode:'HTML'}).text(htmlText).to(chat_id));
bot.send(new Message({parse_mode:'Markdown'}).text(markdownText).to(chat_id));

```
