### PR TITLE
fix(babel): replace window with global

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-if (!window._babelPolyfill) {
+if (!global._babelPolyfill) {
   require('babel-polyfill');
 }
 import API from './functions/api';


### PR DESCRIPTION
I'm pretty sure that here should be `global` instead of `window`.
Does `window` work for you? I have a ReferenceError.
