### PR TITLE
Fix edge case when message object is undefined

### DIFF
--- a/src/types/Base.js
+++ b/src/types/Base.js
@@ -57,7 +57,7 @@ export default class Base extends EventEmitter {
                    && message.reply_to_message.message_id === messageId;
           }
 
-          return message.chat.id === chat;
+          return message && message.chat.id === chat;
         });
 
         if (update) {


### PR DESCRIPTION
It appears when communicating with telegram bot rapidly, entire message object sometimes becomes undefined, hence forcing node.js to throw an underfined 'chat' property error.

This is a quick fix, although it fixes the symptom, I'm not entirely sure it fixes the cause of this error.
Looking forward to your feedback.

Thank you for this awesome lib, BTW! :)