### PR TITLE
Allow module consumers to deal with Promise rejections themselves

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ export default class Bot extends EventEmitter {
    * @return {unknown} returns the result of calling message's send method
    */
   send(message) {
-    return message.send(this).catch(console.error);
+    return message.send(this);
   }
 
   /**

--- a/src/types/Base.js
+++ b/src/types/Base.js
@@ -34,11 +34,11 @@ export default class Base extends EventEmitter {
     }
 
     let messageId;
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       bot.api[this.method](this.properties).then(response => {
         messageId = response.result.message_id;
         this.emit('message:sent', response);
-      });
+      }).catch(reject);
 
       if (this._keyboard.one_time_keyboard) {
         this._keyboard.replyMarkup = '';


### PR DESCRIPTION
Hi again mdibaiee,

I've noticed recently that should Telegram's https://api.telegram.org/bot endpoint return 502 or similar error, the current implementation spews entire error straight to console.error. Which, in my opinion, isn't the most elegant solution, as the error object itself contains a lot of recursive objects and makes entire error log impossible to read and pollutes entire logger (if one is used, say, pm2 native log collector).

Hence I propose a solution that skips spewing error directly into console.error, but rejects bot.send promise instead allowing module consumer to deal with rejections themselves.

Also, provided catch statement in src/index.js eats up the error and continues the promise chain, which on it's own creates potential false-positives.

Hope this makes sense :)