### PR TITLE
Don't merge yet: Keep on listening to Telegram's updates even if requests with telegram server fail

### DIFF
--- a/src/functions/poll.js
+++ b/src/functions/poll.js
@@ -11,7 +11,8 @@ export default function poll(bot) {
         }
         return poll(bot);
       })
-      .catch(() => {
+      .catch(e => {
+        bot.emit('error', e);
         return poll(bot);
       });
 }

--- a/src/functions/poll.js
+++ b/src/functions/poll.js
@@ -1,13 +1,17 @@
 export default function poll(bot) {
-  return bot.api.getUpdates(bot.update).then(response => {
-    if (!response.result.length) {
-      return poll(bot);
-    }
-    bot.emit('update', response.result);
+  return bot.api.getUpdates(bot.update)
+      .then(response => {
+        if (!response.result.length) {
+          return poll(bot);
+        }
+        bot.emit('update', response.result);
 
-    if (bot._stop) {
-      return null;
-    }
-    return poll(bot);
-  });
+        if (bot._stop) {
+          return null;
+        }
+        return poll(bot);
+      })
+      .catch(() => {
+        return poll(bot);
+      });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -75,17 +75,22 @@ export default class Bot extends EventEmitter {
     if (hook) {
       return webhook(hook, this);
     }
-    return this.api.getMe().then(response => {
-      this.info = response.result;
+    return this.api.getMe()
+      .then(response => {
+        this.info = response.result;
 
-      this.on('update', this._update);
+        this.on('update', this._update);
 
-      if (hook) {
-        return webhook(hook, this);
-      }
+        if (hook) {
+          return webhook(hook, this);
+        }
 
-      return poll(this);
-    });
+        return poll(this);
+      })
+      .catch(e => {
+        this.emit('error', e);
+        throw e;
+      });
   }
 
   /**
@@ -138,7 +143,11 @@ export default class Bot extends EventEmitter {
    * @return {unknown} returns the result of calling message's send method
    */
   send(message) {
-    return message.send(this);
+    return message.send(this)
+      .catch(e => {
+        this.emit('error', e);
+        throw e;
+      });
   }
 
   /**


### PR DESCRIPTION
Finally managed to hunt down this edge case that would freeze entire telegram bot if one getUpdates() request fails.

Edit: I'm not really certain about this solution, in terms if it should exist at all.

On one side, this PR provides a convenience to the end module user by simplifying error recovery and guarantees bot's ability to continue to listen to new incomming messages.

On the other, the end user loses ability to take matters into their own hands because of always resolved promise. There could be cases when module user might want to handle connection error with telegram's server in another way.

What would be your suggestion @mdibaiee?

