### PR TITLE
Don't add 'getUpdates' request to the queue

### DIFF
--- a/src/functions/api.js
+++ b/src/functions/api.js
@@ -65,6 +65,11 @@ const methods = ['getMe', 'sendMessage', 'forwardMessage', 'sendPhoto',
 
 methods.forEach(method => {
   API.prototype[method] = function (data) { //eslint-disable-line
+    if (method === 'getUpdates') {
+      // don't add 'getUpdates' request to the queue as it's going to hinder 'send*' calls performance
+      return this.request(method, data);
+    }
+
     // implementation taken from https://github.com/yagop/node-telegram-bot-api/issues/192#issuecomment-249488807
     return new Promise((resolve, reject) => {
       this._queue.push({ method, data, resolve, reject });


### PR DESCRIPTION
I've figured out why after addition of global message queue mechanism introduction all messages get sent out with 20s delay. This is caused by the 'getUpdates' times out exactly after 20s as per default module config. This patch invokes 'getUpdates' right away skipping that request from being added to the message queue hence fixing those message delivery delays.