### PR TITLE
chore: don't copy build/types folder to the project's root; get rid of redundant dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,16 +13,6 @@ module.exports = function(grunt) {
     eslint: {
       scripts: ['src/**/*.js']
     },
-    copy: {
-      classes: {
-        files: [{
-          expand: true,
-          cwd: 'build/types',
-          src: '*',
-          dest: 'types'
-        }]
-      }
-    },
     watch: {
       scripts: {
         files: ['src/**/*.js'],
@@ -35,8 +25,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-babel');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-eslint');
-  grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-clean');
 
-  grunt.registerTask('default', ['clean', 'babel', 'copy', 'eslint']);
+  grunt.registerTask('default', ['clean', 'babel', 'eslint']);
 };

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "url": "https://github.com/mdibaiee/node-telegram-api/issues"
   },
   "files": [
-    "types",
     "build"
   ],
   "directories": {
@@ -46,7 +45,6 @@
     "grunt": "^0.4.5",
     "grunt-babel": "^6.0.0",
     "grunt-contrib-clean": "^1.0.0",
-    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-copy": "^0.1.0",
     "grunt-eslint": "18.0.0"


### PR DESCRIPTION
For no reason `types/` folder used to be copied to the project's root after invoking `grunt` command to build `src` dir.