### PR TITLE
feature: add event listeners to get answers from Base.send method only when explicitly asked

### DIFF
--- a/src/types/Base.js
+++ b/src/types/Base.js
@@ -28,7 +28,7 @@ export default class Base extends EventEmitter {
    * @param {boolean} expectAnswer whether a sent message expects an answer from a contact(s)
    * @return {Promise} returns a promise, resolved with message:answer
    */
-  send(bot, expectAnswer = false) {
+  send(bot, expectAnswer = true) {
     if (this._keyboard) {
       const replyMarkup = JSON.stringify(this._keyboard.getProperties());
       this.properties.reply_markup = replyMarkup;
@@ -43,7 +43,8 @@ export default class Base extends EventEmitter {
         .then(messageId => {
           if (!expectAnswer) {
             // no need to add more event callbacks for the messages that don't need expect an answer
-            return resolve();
+            resolve();
+            return;
           }
 
           const chat = this.properties.chat_id;
@@ -73,8 +74,6 @@ export default class Base extends EventEmitter {
               bot.removeListener('update', listener);
             }
           });
-
-          return void 0;
         })
         .catch(reject)
         .finally(() => {

--- a/src/types/Base.js
+++ b/src/types/Base.js
@@ -25,9 +25,10 @@ export default class Base extends EventEmitter {
    *				                 gets the Update object containing message
    *
    * @param  {object} bot
+   * @param {boolean} expectAnswer whether a sent message expects an answer from a contact(s)
    * @return {Promise} returns a promise, resolved with message:answer
    */
-  send(bot) {
+  send(bot, expectAnswer = false) {
     if (this._keyboard) {
       const replyMarkup = JSON.stringify(this._keyboard.getProperties());
       this.properties.reply_markup = replyMarkup;
@@ -40,6 +41,11 @@ export default class Base extends EventEmitter {
           return response.result.message_id;
         })
         .then(messageId => {
+          if (!expectAnswer) {
+            // no need to add more event callbacks for the messages that don't need expect an answer
+            return resolve();
+          }
+
           const chat = this.properties.chat_id;
           let answers = 0;
 
@@ -67,6 +73,8 @@ export default class Base extends EventEmitter {
               bot.removeListener('update', listener);
             }
           });
+
+          return void 0;
         })
         .catch(reject)
         .finally(() => {

--- a/src/types/Question.js
+++ b/src/types/Question.js
@@ -44,8 +44,9 @@ export default class Question extends Message {
    */
   send(bot) {
     const answers = this._answers;
+    const expectAnswer = true;
 
-    return super.send(bot).then(message => {
+    return super.send(bot, expectAnswer).then(message => {
       let answer;
 
       answers.forEach(function find(a) {

--- a/src/types/Question.js
+++ b/src/types/Question.js
@@ -44,9 +44,8 @@ export default class Question extends Message {
    */
   send(bot) {
     const answers = this._answers;
-    const expectAnswer = true;
 
-    return super.send(bot, expectAnswer).then(message => {
+    return super.send(bot).then(message => {
       let answer;
 
       answers.forEach(function find(a) {


### PR DESCRIPTION
In my particular use case I might be sending many messages to a contact from bot without ever expecting an answer to sent message. I've noticed that only Question class is actually dealing with `question:answer` event. Otherwise a process can end up having many event listeners stacking up in the EventEmitter's instance without being actually called as there's no response from the contact ever, thus triggering nodejs throwing an error like (this is *after* me increasing event listener max count):
```
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 201 update listeners added. Use emitter.setMaxListeners() to increase limit
```